### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@ Check the playground for usage doc and test will come later
 1. Add `nuxt-zod-i18n` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-zod-i18n
-
-# Using yarn
-yarn add --dev nuxt-zod-i18n
-
-# Using npm
-npm install --save-dev nuxt-zod-i18n
+npx nuxi@latest module add nuxt-zod-i18n
 ```
 
 2. Add `nuxt-zod-i18n` to the `modules` section of `nuxt.config.ts` before `@nuxtjs/i18n` module

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -6,18 +6,9 @@ description: 'Get started with zodI18n.'
 ## Quick Start
 
 1. Install `nuxt-zod-i18n` dependency to your project:
-
-::code-group
-  ```bash [pnpm]
-  pnpm add -D nuxt-zod-i18n
-  ```
-  ```bash [yarn]
-  yarn add --dev nuxt-zod-i18n
-  ```
-  ```bash [npm]
-  npm install --save-dev nuxt-zod-i18n
-  ```
-::
+```bash
+npx nuxi@latest module add nuxt-zod-i18n
+```
 
 2. Add it to your `modules` section in your `nuxt.config`:
 

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -24,17 +24,9 @@ hero:
       size: lg
   code: |
     # Quick Setup
-    ::code-group
-      ```bash [pnpm]
-      pnpm add -D nuxt-zod-i18n
-      ```
-      ```bash [yarn]
-      yarn add --dev nuxt-zod-i18n
-      ```
-      ```bash [npm]
-      npm install --save-dev nuxt-zod-i18n
-      ```
-    ::
+    ```bash
+    npx nuxi@latest module add nuxt-zod-i18n
+    ```
     ```ts [nuxt.config.ts]
     export default defineNuxtConfig({
       modules: ['nuxt-zod-i18n', '@nuxtjs/i18n']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
