### PR TITLE
feat: add option to use existing locales + add not to docs about parallelPlugin Nuxt i18n option

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -27,3 +27,7 @@ That's it! You can now use all the components and composables in your Nuxt app â
 ::callout{icon="i-heroicons-exclamation-information-circle"}
 This module require [@nuxtjs/i18n](https://i18n.nuxtjs.org/) and [zod](https://zod.dev/) to be installed.
 ::
+
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+You must have Nuxt i18n module `parallelPlugin` option set to `false`.
+::

--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -53,3 +53,10 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+## `useExistingLocales`
+
+- Type: `boolean`
+- Default: `undefined`
+
+Use the locales of this package instead of relying on translations with key `zodI18n` existing already.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. Add an option to use "local" `zodI18n` translations instead of registering them during plugin setup.
2. Added a note about Nuxt i18n `parallelPlugin` option needing to be `false` as otherwise there might be issues such as `i18n is undefined`.

I'm happy to make any changes to the code that I added, for the note about `parallelPlugin` I wasn't sure how to write as it cost me a few hours so it is brief to the point :laughing:

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
